### PR TITLE
boto3: always disable Termination Protection

### DIFF
--- a/avocado_ec2/ec2_wrapper.py
+++ b/avocado_ec2/ec2_wrapper.py
@@ -106,6 +106,7 @@ class EC2InstanceWrapper(object):
     @clean_aws_resources
     def _init_resources(self, args):
         self.ec2 = boto3.resource('ec2')
+        self.ec2_client = boto3.client('ec2')
         self.key_pair = KeyPairWrapper(service=self.ec2, name=self.name)
         global EC2_KEYPAIR_WRAPPERS
         EC2_KEYPAIR_WRAPPERS.append(self.key_pair)
@@ -120,6 +121,8 @@ class EC2InstanceWrapper(object):
         global EC2_INSTANCES
         EC2_INSTANCES += inst_list
         self.instance = inst_list[0]
+        self.ec2_client.modify_instance_attribute(DisableApiTermination={'Value': False},
+                                                  InstanceId=self.instance.id)
         log = logging.getLogger("avocado.app")
         log.info("EC2_ID     : %s", self.instance.id)
         # Rename the instance


### PR DESCRIPTION
Our latest artifacts tests of enterprise have problem to destroy instance,
fix it by disabling Termination Protection all the time.

Avocado job failed: JobError: An error occurred (OperationNotPermitted)
when calling the TerminateInstances operation: The instance
'i-024d3d82f7f1ec461' may not be terminated. Modify its 'disableApiTermination'
instance attribute and try again.