### PR TITLE
update repo url for installing avocado [v2]

### DIFF
--- a/avocado_ec2/plugins/ec2.py
+++ b/avocado_ec2/plugins/ec2.py
@@ -91,17 +91,17 @@ class EC2TestRunner(RemoteTestRunner):
             log.error(e_msg)
             raise ValueError(e_msg)
         if distro_type == 'fedora':
-            remote_repo = ('https://repos-avocadoproject.rhcloud.com/static/'
+            remote_repo = ('https://avocado-project.org/data/repos/'
                            'avocado-fedora.repo')
             local_repo = '/etc/yum.repos.d/avocado.repo'
             retrieve_cmd = 'sudo curl %s -o %s' % (remote_repo, local_repo)
-            install_cmd = 'sudo dnf install -y avocado'
+            install_cmd = 'sudo dnf install -y python-avocado'
         elif distro_type == 'el':
-            remote_repo = ('https://repos-avocadoproject.rhcloud.com/static/'
+            remote_repo = ('https://avocado-project.org/data/repos/'
                            'avocado-el.repo')
             local_repo = '/etc/yum.repos.d/avocado.repo'
             retrieve_cmd = 'sudo curl %s -o %s' % (remote_repo, local_repo)
-            install_cmd = 'sudo yum install -y avocado'
+            install_cmd = 'sudo yum install -y python-avocado'
         elif distro_type == 'ubuntu':
             remote_repo = ('deb http://ppa.launchpad.net/lmr/avocado/ubuntu '
                            'wily main')


### PR DESCRIPTION
rhcloud repos aren't valid, they were moved to avocado-project.org
This patch updated the repo url.

Signed-off-by: Amos Kong <amos@scylladb.com>
Signed-off-by: Cleber Rosa <crosa@redhat.com>

---

Changes from v1 (#5):
 * Update URL to use HTTPS