### PR TITLE
wait until the instance exists before modify its attribute

### DIFF
--- a/avocado_ec2/ec2_wrapper.py
+++ b/avocado_ec2/ec2_wrapper.py
@@ -120,6 +120,7 @@ class EC2InstanceWrapper(object):
         global EC2_INSTANCES
         EC2_INSTANCES += inst_list
         self.instance = inst_list[0]
+        self.instance.wait_until_exists()
         log = logging.getLogger("avocado.app")
         log.info("EC2_ID     : %s", self.instance.id)
         # Rename the instance


### PR DESCRIPTION
Sometimes, instance can't be created immediately, it failed to modify its
name attribute for that instance doesn't exist.

This patch added wait to make sure the instance exists.