### PR TITLE
ignore exception if instance doesn't exist in terminate

### DIFF
--- a/avocado_ec2/ec2_wrapper.py
+++ b/avocado_ec2/ec2_wrapper.py
@@ -17,6 +17,7 @@ import uuid
 import logging
 
 import boto3
+from botocore.exceptions import ClientError
 
 try:
     from botocore.vendored.requests.packages.urllib3.contrib.pyopenssl import extract_from_urllib3
@@ -43,7 +44,11 @@ def clean_aws_resources_atexit():
     global EC2_KEYPAIR_WRAPPERS
 
     for instance in EC2_INSTANCES:
-        instance.terminate()
+        try:
+            instance.terminate()
+        except ClientError as e:
+            if 'InvalidInstanceID.NotFound' not in e.message:
+                raise
 
     for key_pair in EC2_KEYPAIR_WRAPPERS:
         key_pair.destroy()


### PR DESCRIPTION
Sometimes EC2 failed to create an instance, the instance can't be available.
Problem occurred if our code tries to terminate the instance.

Traceback (most recent call last):
  File "/usr/lib64/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(*targs, **kargs)
  File "/usr/lib/python2.7/site-packages/avocado_ec2/ec2_wrapper.py", line 46, in clean_aws_resources_atexit
    instance.terminate()
  File "/usr/lib/python2.7/site-packages/boto3/resources/factory.py", line 455, in do_action
    response = action(self, *args, **kwargs)
  File "/usr/lib/python2.7/site-packages/boto3/resources/action.py", line 79, in __call__
    response = getattr(parent.meta.client, operation_name)(**params)
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 310, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 395, in _make_api_call
    raise ClientError(parsed_response, operation_name)
ClientError: An error occurred (InvalidInstanceID.NotFound) when calling the TerminateInstances operation: The instance ID 'i-0d0210cadfabc6eba' does not exist
